### PR TITLE
fix: better errors from reading and parskign package.json

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,12 @@ async function run() {
 
     for (const {path: filepath, repository: { name, html_url, node_id }} of reposList) {
       if (ignoredRepositories.includes(name)) continue;
+      //Sometimes there might be files like package.json.js or similar as the repository might contain some templated package.json files that cannot be parsed from string to JSON
+      //Such files must be ignored 
+      if (filepath.substring(filepath.lastIndexOf('/') + 1) !== 'package.json') {
+        core.info(`Ignoring ${filepath} from ${name} repo as only package.json files are supported`);
+        continue;
+      }
 
       const cloneDir = path.join(process.cwd(), './clones', name);
       await mkdir(cloneDir, {recursive: true});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,9 +8,19 @@ module.exports = { readPackageJson, parseCommaList, verifyDependencyType, instal
  * @returns parsed package.json
  */
 async function readPackageJson(path) {
-  return JSON.parse(
-    await readFile(path, 'utf8')
-  );
+  let packageFile, parsedFile;
+
+  try {
+    packageFile = await readFile(path, 'utf8');
+  } catch (e) {
+    throw new Error(`There was a problem reading the package.json file from ${path}`, e);
+  }
+  try {
+    parsedFile = JSON.parse(packageFile);
+  } catch (e) {
+    throw new Error(`There was a problem parsing the package.json file from ${path} with the following content: ${packageFile}`);
+  }
+  return parsedFile;
 }
 
 /**


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- better errors when reading and parsing package.json
- make sure `package.json.js` or different files are not read by the action and ignored. Only `package.json` files should be read