### PR TITLE
fix: remove default values from action.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ github_token | Token to use GitHub API. It must have "repo" scopes so it can pus
 packagejson_path | Path to package.json file if not located in the root of the project. Provide just the path without file name. In the format: `./nested/location`. | false | `./`
 committer_username | The username (not display name) of the committer will be used to commit changes in the workflow file in a specific repository. In the format `web-flow`. | false | `web-flow`
 committer_email | The committer's email that will be used in the commit of changes in the workflow file in a specific repository. In the format `noreply@github.com`.| false | `noreply@github.com`
-commit_message_prod | It is used as a commit message when bumping dependency from "dependencies" section in package.json. In case dependency is located in both dependencies and devDependencies of dependant, then prod commit message is used. It is also used as a title of the pull request that is created by this action. | false | `Update dependency`
-commit_message_dev | It is used as a commit message when bumping dependency from "devDependencies" section in package.json. It is also used as a title of the pull request that is created by this action. | false | `Update devDependency`
+commit_message_prod | It is used as a commit message when bumping dependency from "dependencies" section in package.json. In case dependency is located in both dependencies and devDependencies of dependant, then prod commit message is used. It is also used as a title of the pull request that is created by this action. | false | `fix: update ${dependencyName} to ${dependencyVersion} version`
+commit_message_dev | It is used as a commit message when bumping dependency from "devDependencies" section in package.json. It is also used as a title of the pull request that is created by this action. | false | `chore: update ${dependencyName} to ${dependencyVersion} version`
 repos_to_ignore | Comma-separated list of repositories that should not get updates from this action. Action already ignores the repo in which the action is triggered so you do not need to add it explicitly. In the format `repo1,repo2`. | false | -
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -24,13 +24,11 @@ inputs:
       It is used as a commit message when bumping dependency from "dependencies" section in package.json. 
       In case dependency is located in both dependencies and devDependencies of dependant, then prod commit message is used.
       It is also used as a title of the pull request that is created by this action.
-    default: 'fix: update ${dependencyName} to ${dependencyVersion} version'
     required: false
   commit_message_dev:
     description: >
       It is used as a commit message when bumping dependency from "devDependencies" section in package.json. 
       It is also used as a title of the pull request that is created by this action.
-    default: 'chore: update ${dependencyName} to ${dependencyVersion} version'
     required: false
   packagejson_path:
     description: >


### PR DESCRIPTION
`default` values from action.yml are not for docs only but actually they are also used in action. This was causing wrong default message instead of proper commit message with package name and version