### PR TITLE
fix: remove duplicated repositories from list of repos to iterate over

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ GitHub Action that handles automated update of dependencies in package.json betw
 - [Configuration](#configuration)
 - [Example](#example)
 - [Development](#development)
+- [Debug](#debug)
 
 <!-- tocstop -->
 
@@ -97,3 +98,7 @@ jobs:
 # PACKAGE_JSON_LOC=test is a path to package.json file against you want to test
 GITHUB_TOKEN=token PACKAGE_JSON_LOC=test GITHUB_REPOSITORY="lukasz-lab/.github" npm start
 ```
+
+## Debug
+
+In case something ain't right, the action doesn't work as expected, enable debugging. Add to **Secrets** of the repository a secret called `ACTIONS_STEP_DEBUG` with value `true`. Now, once you run the action again, there will be additional logs visible that start with `DEBUG: `.

--- a/lib/api-calls.js
+++ b/lib/api-calls.js
@@ -11,6 +11,10 @@ async function getReposList(octokit, name, owner) {
   
     return prevItem;
   }, []);
+  
+  let processedRepo = {};
+  // filter() returns only the repos that are not present in processedRepo object, and adds them there to the list
+  const deduplicatedReposList = items.filter(({ repository: { id }}) => !processedRepo[id] && (processedRepo[id] = true));
 
   return deduplicatedReposList;
 }

--- a/lib/api-calls.js
+++ b/lib/api-calls.js
@@ -6,11 +6,11 @@ async function getReposList(octokit, name, owner) {
   });
 
   const deduplicatedReposList = reposList.reduce((prevItem, currentItem) => {
-      if (prevItem.find(item => item.repository.id == currentItem.repository.id)) return prevItem;
-      prevItem.push(currentItem);
+    if (prevItem.find(item => item.repository.id == currentItem.repository.id)) return prevItem;
+    prevItem.push(currentItem);
   
-      return prevItem;
-    }, []);
+    return prevItem;
+  }, []);
 
   return deduplicatedReposList;
 }

--- a/lib/api-calls.js
+++ b/lib/api-calls.js
@@ -4,13 +4,6 @@ async function getReposList(octokit, name, owner) {
   const { data: { items } } = await octokit.search.code({
     q: `"${name}" user:${owner} in:file filename:package.json`
   });
-
-  const deduplicatedReposList = reposList.reduce((prevItem, currentItem) => {
-    if (prevItem.find(item => item.repository.id == currentItem.repository.id)) return prevItem;
-    prevItem.push(currentItem);
-  
-    return prevItem;
-  }, []);
   
   let processedRepo = {};
   // filter() returns only the repos that are not present in processedRepo object, and adds them there to the list

--- a/lib/api-calls.js
+++ b/lib/api-calls.js
@@ -5,7 +5,14 @@ async function getReposList(octokit, name, owner) {
     q: `"${name}" user:${owner} in:file filename:package.json`
   });
 
-  return items;
+  const deduplicatedReposList = reposList.reduce((prevItem, currentItem) => {
+      if (prevItem.find(item => item.repository.id == currentItem.repository.id)) return prevItem;
+      prevItem.push(currentItem);
+  
+      return prevItem;
+    }, []);
+
+  return deduplicatedReposList;
 }
 
 async function createPr(octokit, branchName, id, commitMessage, defaultBranch) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,9 @@ async function run() {
     ignoredRepositories.push(repo);
 
     const reposList = await getReposList(octokit, dependencyName, owner);
+    core.debug('DEBUG: List of all repost returned by search without duplicates:');
+    core.debug(JSON.stringify(reposList, null, 2));
+    
     const foundReposAmount = reposList.length;
     if (!foundReposAmount) return core.info(`No dependants found. No version bump performed. Looks like you do not use ${dependencyName} in your organization :man_shrugging:`);
 


### PR DESCRIPTION
This PR changes the `getReposList` function to return a list of repos that doesn't contain duplicates.
On the issue, we discussed using a `Set`, but since the `has` method will only check for equality on primitive values or object references, it doesn't seem to suit this use case.

**Related issue(s)**
Resolves #6 

Let me know your thoughts on this 👍 