### PR TITLE
feat!: add base_branch support and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Organization Projects' Dependency Manager
 GitHub Action that handles automated update of dependencies in package.json between projects from the same GitHub organization. You run this workflow after npm package release. It searches for libraries in your GitHub organization that depend on this package and bump version through a PR flow.
 
+While updating multiple repositories, if there are issues with one of them, the action doesn't fail but continues bumping deps in next repo from the list. 
+
 <!-- toc -->
 
 - [Why I Created This Action?](#why-i-created-this-action)
@@ -57,6 +59,7 @@ committer_email | The committer's email that will be used in the commit of chang
 commit_message_prod | It is used as a commit message when bumping dependency from "dependencies" section in package.json. In case dependency is located in both dependencies and devDependencies of dependant, then prod commit message is used. It is also used as a title of the pull request that is created by this action. | false | `fix: update ${dependencyName} to ${dependencyVersion} version`
 commit_message_dev | It is used as a commit message when bumping dependency from "devDependencies" section in package.json. It is also used as a title of the pull request that is created by this action. | false | `chore: update ${dependencyName} to ${dependencyVersion} version`
 repos_to_ignore | Comma-separated list of repositories that should not get updates from this action. Action already ignores the repo in which the action is triggered so you do not need to add it explicitly. In the format `repo1,repo2`. | false | -
+base_branch | Name of the base branch, where changes in package.json must be applied. It is used in PR creation. If not provided, default branch is used. In the format: `next-major`. | false | -
 
 ## Example
 
@@ -77,10 +80,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Bumping
-        uses: derberg/npm-dependency-manager-for-your-github-org@v3
+        uses: derberg/npm-dependency-manager-for-your-github-org@v4
         with:
           github_token: ${{ secrets.CUSTOM_TOKEN }}
           repos_to_ignore: repo1,repo2
+          base_branch: next-major
           packagejson_path: ./custom/path
           committer_username: pomidor
           committer_email: pomidor@pomidor.com

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ committer_email | The committer's email that will be used in the commit of chang
 commit_message_prod | It is used as a commit message when bumping dependency from "dependencies" section in package.json. In case dependency is located in both dependencies and devDependencies of dependant, then prod commit message is used. It is also used as a title of the pull request that is created by this action. | false | `fix: update ${dependencyName} to ${dependencyVersion} version`
 commit_message_dev | It is used as a commit message when bumping dependency from "devDependencies" section in package.json. It is also used as a title of the pull request that is created by this action. | false | `chore: update ${dependencyName} to ${dependencyVersion} version`
 repos_to_ignore | Comma-separated list of repositories that should not get updates from this action. Action already ignores the repo in which the action is triggered so you do not need to add it explicitly. In the format `repo1,repo2`. | false | -
-base_branch | Name of the base branch, where changes in package.json must be applied. It is used in PR creation. If not provided, default branch is used. In the format: `next-major`. | false | -
+base_branch | Name of the base branch, where changes in package.json must be applied. It is used in PR creation. Branch where changes are introduced is cut from this base branch. If not provided, default branch is used. In the format: `next-major`. | false | -
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,11 @@ inputs:
       Action already ignores the repo in which the action is triggered so you do not need to add it explicitly.
       In the format: `repo1,repo2`.
     required: false
+  base_branch:
+    description: >
+      Name of the base branch, where changes in package.json must be applied. It is used in PR creation. If not provided, default branch is used
+      In the format: `next-major`.
+    required: false
 runs:
   using: node12
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -11495,7 +11495,12 @@ async function run() {
     core.info(`Clonning ${name}.`);
     try {
       await clone(html_url, cloneDir, git);
-      if (baseBranchName) await checkout(baseBranchWhereApplyChanges);
+      //in case some different than default branch was provided in config
+      //after clonning repo, we need to checkout this specific branch
+      if (baseBranchName) {
+        core.info(`Checking out branch ${baseBranchWhereApplyChanges}.`);
+        await checkout(baseBranchWhereApplyChanges);
+      }
     } catch (error) {
       core.warning(`Cloning failed: ${ error}`);
       continue;

--- a/dist/index.js
+++ b/dist/index.js
@@ -5665,7 +5665,7 @@ async function createBranch(branchName, git) {
 
 async function checkout(branchName, git) {
   return await git
-    .fetch(remoteName, branchName)
+    .fetch('origin', branchName)
     .checkout(branchName);
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -11499,7 +11499,7 @@ async function run() {
       //after clonning repo, we need to checkout this specific branch
       if (baseBranchName) {
         core.info(`Checking out branch ${baseBranchWhereApplyChanges}.`);
-        await checkout(baseBranchWhereApplyChanges);
+        await checkout(baseBranchWhereApplyChanges, git);
       }
     } catch (error) {
       core.warning(`Cloning failed: ${ error}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -5656,6 +5656,8 @@ exports.parseStringResponse = parseStringResponse;
 
 module.exports = {createBranch, clone, push, removeRemoteBranch, checkout};
 
+const remoteName = 'auth';
+
 async function createBranch(branchName, git) {
   return await git
     .checkout(`-b${branchName}`);
@@ -5682,12 +5684,13 @@ async function push(token, url, branchName, message, committerUsername, committe
     .addConfig('user.name', committerUsername)
     .addConfig('user.email', committerEmail)
     .commit(message)
-    .addRemote('auth', authanticatedUrl(token, url, committerUsername))
-    .push(['-u', 'auth', branchName]);
+    .addRemote(remoteName, authanticatedUrl(token, url, committerUsername))
+    .fetch()
+    .push(['-u', remoteName, branchName]);
 }
 
 async function removeRemoteBranch(branchName, git) {
-  return await git.push(['-u', 'auth', branchName, '--delete', '--force']);
+  return await git.push(['-u', remoteName, branchName, '--delete', '--force']);
 }
   
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -11480,7 +11480,6 @@ async function run() {
     const baseBranchWhereApplyChanges = baseBranchName || await getRepoDefaultBranch(octokit, name, owner);
     const branchName = `bot/bump-${dependencyName}-${dependencyVersion}`;
     const cloneDir = __webpack_require__.ab + "clones/" + name;
-    const git = simpleGit({baseDir: cloneDir});
 
     try {
       await mkdir(cloneDir, {recursive: true});
@@ -11488,6 +11487,8 @@ async function run() {
       core.warning(`Unable to create directory where close should end up: ${ error}`);
     }
 
+    const git = simpleGit({baseDir: cloneDir});
+    
     core.info(`Clonning ${name} with branch ${baseBranchWhereApplyChanges}.`);
     try {
       await clone(html_url, cloneDir, baseBranchWhereApplyChanges, git);

--- a/dist/index.js
+++ b/dist/index.js
@@ -5665,6 +5665,7 @@ async function createBranch(branchName, git) {
 
 async function checkout(branchName, git) {
   return await git
+    .fetch(remoteName, branchName)
     .checkout(branchName);
 }
 
@@ -5685,7 +5686,6 @@ async function push(token, url, branchName, message, committerUsername, committe
     .addConfig('user.email', committerEmail)
     .commit(message)
     .addRemote(remoteName, authanticatedUrl(token, url, committerUsername))
-    .fetch()
     .push(['-u', remoteName, branchName]);
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -5654,7 +5654,7 @@ exports.parseStringResponse = parseStringResponse;
 /***/ 374:
 /***/ (function(module) {
 
-module.exports = {createBranch, clone, push};
+module.exports = {createBranch, clone, push, removeRemoteBranch};
 
 async function createBranch(branchName, git) {
   return await git
@@ -5679,6 +5679,10 @@ async function push(token, url, branchName, message, committerUsername, committe
     .commit(message)
     .addRemote('auth', authanticatedUrl(token, url, committerUsername))
     .push(['-u', 'auth', branchName]);
+}
+
+async function removeRemoteBranch(branchName, git) {
+  return await git.push(['-u', 'auth', branchName, '--delete', '--force']);
 }
   
 
@@ -11421,7 +11425,7 @@ const simpleGit = __webpack_require__(477);
 const path = __webpack_require__(622);
 const {mkdir} = __webpack_require__(747).promises;
 
-const { createBranch, clone, push } = __webpack_require__(374);
+const { createBranch, clone, push, removeRemoteBranch } = __webpack_require__(374);
 const { getReposList, createPr, getRepoDefaultBranch } = __webpack_require__(119);
 const { readPackageJson, parseCommaList, verifyDependencyType, installDependency } = __webpack_require__(918);
 
@@ -11431,79 +11435,127 @@ const { readPackageJson, parseCommaList, verifyDependencyType, installDependency
  * It looks complex because of extensive usage of core package to log as much as possible
  */
 async function run() {
+  const gitHubKey = process.env.GITHUB_TOKEN || core.getInput('github_token', { required: true });
+  const committerUsername = core.getInput('committer_username') || 'web-flow';
+  const committerEmail = core.getInput('committer_email') || 'noreply@github.com';
+  const packageJsonPath = process.env.PACKAGE_JSON_LOC || core.getInput('packagejson_path') || './';
+  const { name: dependencyName, version: dependencyVersion} = await readPackageJson(path.join(packageJsonPath, 'package.json'));
+  core.info(`Identified dependency name as ${dependencyName} with version ${dependencyVersion}. Now it will be bumped in dependent projects.`);
+  const commitMessageProd = core.getInput('commit_message_prod') || `fix: update ${dependencyName} to ${dependencyVersion} version`;
+  const commitMessageDev = core.getInput('commit_message_dev') || `chore: update ${dependencyName} to ${dependencyVersion} version`;
+  const reposToIgnore = core.getInput('repos_to_ignore');
+  const baseBranchName = core.getInput('base_branch');
+
+  const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+  const octokit = github.getOctokit(gitHubKey);
+  const ignoredRepositories = reposToIgnore ? parseCommaList(reposToIgnore) : [];
+  //by default repo where workflow runs should always be ignored
+  let reposList;
+
   try {
-    const gitHubKey = process.env.GITHUB_TOKEN || core.getInput('github_token', { required: true });
-    const committerUsername = core.getInput('committer_username') || 'web-flow';
-    const committerEmail = core.getInput('committer_email') || 'noreply@github.com';
-    const packageJsonPath = process.env.PACKAGE_JSON_LOC || core.getInput('packagejson_path') || './';
-    const { name: dependencyName, version: dependencyVersion} = await readPackageJson(path.join(packageJsonPath, 'package.json'));
-    core.info(`Identified dependency name as ${dependencyName} with version ${dependencyVersion}. Now it will be bumped in dependent projects.`);
-    const commitMessageProd = core.getInput('commit_message_prod') || `fix: update ${dependencyName} to ${dependencyVersion} version`;
-    const commitMessageDev = core.getInput('commit_message_dev') || `chore: update ${dependencyName} to ${dependencyVersion} version`;
-    const reposToIgnore = core.getInput('repos_to_ignore');
-
-    const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-    const octokit = github.getOctokit(gitHubKey);
-    const ignoredRepositories = reposToIgnore ? parseCommaList(reposToIgnore) : [];
-    //by default repo where workflow runs should always be ignored
-    ignoredRepositories.push(repo);
-
-    const reposList = await getReposList(octokit, dependencyName, owner);
-    core.debug('DEBUG: List of all repost returned by search without duplicates:');
-    core.debug(JSON.stringify(reposList, null, 2));
+    reposList = await getReposList(octokit, dependencyName, owner);
+  } catch (error) {
+    core.setFailed(`Action failed while getting list of repos to process: ${ error}`);
+  }
     
-    const foundReposAmount = reposList.length;
-    if (!foundReposAmount) return core.info(`No dependants found. No version bump performed. Looks like you do not use ${dependencyName} in your organization :man_shrugging:`);
+  core.debug('DEBUG: List of all repost returned by search without duplicates:');
+  core.debug(JSON.stringify(reposList, null, 2));
+    
+  const foundReposAmount = reposList.length;
+  if (!foundReposAmount) return core.info(`No dependants found. No version bump performed. Looks like you do not use ${dependencyName} in your organization :man_shrugging:`);
 
-    core.startGroup(`Iterating over ${foundReposAmount} repos from ${owner} that have ${dependencyName} in their package.json. The following repos will be later ignored: ${ignoredRepositories}`);
+  core.startGroup(`Iterating over ${foundReposAmount} repos from ${owner} that have ${dependencyName} in their package.json. The following repos will be later ignored: ${ignoredRepositories}`);
 
-    for (const {path: filepath, repository: { name, html_url, node_id }} of reposList) {
-      if (ignoredRepositories.includes(name)) continue;
-      //Sometimes there might be files like package.json.js or similar as the repository might contain some templated package.json files that cannot be parsed from string to JSON
-      //Such files must be ignored 
-      if (filepath.substring(filepath.lastIndexOf('/') + 1) !== 'package.json') {
-        core.info(`Ignoring ${filepath} from ${name} repo as only package.json files are supported`);
-        continue;
-      }
-
-      const cloneDir = __webpack_require__.ab + "clones/" + name;
-      await mkdir(cloneDir, {recursive: true});
-
-      const branchName = `bot/bump-${dependencyName}-${dependencyVersion}`;
-      const git = simpleGit({baseDir: cloneDir});
-
-      core.info(`Clonning ${name}.`);
-      await clone(html_url, cloneDir, git);
-      
-      core.info(`Creating branch ${branchName}.`);
-      await createBranch(branchName, git);
-      
-      core.info('Checking if dependency is prod, dev or both');
-      const packageJsonLocation = path.join(cloneDir, filepath);
-      const packageJson = await readPackageJson(packageJsonLocation);
-      const dependencyType = await verifyDependencyType(packageJson, dependencyName);
-      if (dependencyType === 'NONE') {
-        core.info(`We could not find ${dependencyName} neither in dependencies property nor in the devDependencies property. No further steps will be performed. It was found as GitHub search is not perfect and you probably use a package with similar name.`);
-        continue;
-      }
-
-      core.info('Bumping version');
-      await installDependency(dependencyName, dependencyVersion, packageJsonLocation);
-      const commitMessage = dependencyType === 'PROD' ? commitMessageProd : commitMessageDev;
-
-      core.info('Pushing changes to remote');
-      await push(gitHubKey, html_url, branchName, commitMessage, committerUsername, committerEmail, git);
-      
-      core.info('Creating PR');
-      const pullRequestUrl = await createPr(octokit, branchName, node_id, commitMessage, await getRepoDefaultBranch(octokit, name, owner));
-      
-      core.info(`Finished with success and PR for ${name} is created -> ${pullRequestUrl}`);
+  for (const {path: filepath, repository: { name, html_url, node_id }} of reposList) {
+    if (ignoredRepositories.includes(name)) continue;
+    //Sometimes there might be files like package.json.js or similar as the repository might contain some templated package.json files that cannot be parsed from string to JSON
+    //Such files must be ignored 
+    if (filepath.substring(filepath.lastIndexOf('/') + 1) !== 'package.json') {
+      core.info(`Ignoring ${filepath} from ${name} repo as only package.json files are supported`);
+      continue;
     }
 
-    core.endGroup();
-  } catch (error) {
-    core.setFailed(`Action failed because of: ${ error}`);
+    const cloneDir = __webpack_require__.ab + "clones/" + name;
+    try {
+      await mkdir(cloneDir, {recursive: true});
+    } catch (error) {
+      core.warning(`Unable to create directory where close should end up: ${ error}`);
+    }
+
+    const branchName = `bot/bump-${dependencyName}-${dependencyVersion}`;
+    const git = simpleGit({baseDir: cloneDir});
+
+    core.info(`Clonning ${name}.`);
+    try {
+      await clone(html_url, cloneDir, git);
+    } catch (error) {
+      core.warning(`Cloning failed: ${ error}`);
+      continue;
+    }
+      
+    core.info(`Creating branch ${branchName}.`);
+    try {
+      await createBranch(branchName, git);
+    } catch (error) {
+      core.warning(`Branch creation failes: ${ error}`);
+      continue;
+    }
+      
+    core.info('Checking if dependency is prod, dev or both');
+    const packageJsonLocation = path.join(cloneDir, filepath);
+    let packageJson;
+    let dependencyType;
+    try {
+      packageJson = await readPackageJson(packageJsonLocation);
+      dependencyType = await verifyDependencyType(packageJson, dependencyName);
+    } catch (error) {
+      core.warning(`Verification of dependency failed: ${ error}`);
+      continue;
+    }
+      
+    if (dependencyType === 'NONE') {
+      core.info(`We could not find ${dependencyName} neither in dependencies property nor in the devDependencies property. No further steps will be performed. It was found as GitHub search is not perfect and you probably use a package with similar name.`);
+      continue;
+    }
+
+    core.info('Bumping version');
+    try {
+      await installDependency(dependencyName, dependencyVersion, packageJsonLocation);
+    } catch (error) {
+      core.warning(`Dependency installation failed: ${ error}`);
+      continue;
+    }
+    const commitMessage = dependencyType === 'PROD' ? commitMessageProd : commitMessageDev;
+
+    core.info('Pushing changes to remote');
+    try {
+      await push(gitHubKey, html_url, branchName, commitMessage, committerUsername, committerEmail, git);
+    } catch (error) {
+      core.warning(`Pushing changes failed: ${ error}`);
+      continue;
+    }
+      
+    let pullRequestUrl;
+    const baseBranchWhereApplyChanges = baseBranchName || await getRepoDefaultBranch(octokit, name, owner);
+    core.info('Creating PR');
+    try {
+      pullRequestUrl = await createPr(octokit, branchName, node_id, commitMessage, baseBranchWhereApplyChanges);
+    } catch (error) {
+      core.warning(`Opening PR failed: ${ error}`);
+      core.info('Attempting to remove branch that was initially pushed to remote');
+      try {
+        //we should cleanup dead branch from remote if PR creation is not possible
+        await removeRemoteBranch(branchName, git);
+      } catch (error) {
+        core.warning(`Could not remove branch in remote after failed PR creation: ${ error}`);
+      }
+      continue;
+    }
+      
+    core.info(`Finished with success and PR for ${name} is created -> ${pullRequestUrl}`);
   }
+
+  core.endGroup();
 }
 
 run();

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,5 +1,7 @@
 module.exports = {createBranch, clone, push, removeRemoteBranch, checkout};
 
+const remoteName = 'auth';
+
 async function createBranch(branchName, git) {
   return await git
     .checkout(`-b${branchName}`);
@@ -26,11 +28,12 @@ async function push(token, url, branchName, message, committerUsername, committe
     .addConfig('user.name', committerUsername)
     .addConfig('user.email', committerEmail)
     .commit(message)
-    .addRemote('auth', authanticatedUrl(token, url, committerUsername))
-    .push(['-u', 'auth', branchName]);
+    .addRemote(remoteName, authanticatedUrl(token, url, committerUsername))
+    .fetch()
+    .push(['-u', remoteName, branchName]);
 }
 
 async function removeRemoteBranch(branchName, git) {
-  return await git.push(['-u', 'auth', branchName, '--delete', '--force']);
+  return await git.push(['-u', remoteName, branchName, '--delete', '--force']);
 }
   

--- a/lib/git.js
+++ b/lib/git.js
@@ -9,7 +9,7 @@ async function createBranch(branchName, git) {
 
 async function checkout(branchName, git) {
   return await git
-    .fetch(remoteName, branchName)
+    .fetch('origin', branchName)
     .checkout(branchName);
 }
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,8 +1,13 @@
-module.exports = {createBranch, clone, push, removeRemoteBranch};
+module.exports = {createBranch, clone, push, removeRemoteBranch, checkout};
 
 async function createBranch(branchName, git) {
   return await git
     .checkout(`-b${branchName}`);
+}
+
+async function checkout(branchName, git) {
+  return await git
+    .checkout(branchName);
 }
 
 async function clone(remote, dir, git) {

--- a/lib/git.js
+++ b/lib/git.js
@@ -9,6 +9,7 @@ async function createBranch(branchName, git) {
 
 async function checkout(branchName, git) {
   return await git
+    .fetch(remoteName, branchName)
     .checkout(branchName);
 }
 
@@ -29,7 +30,6 @@ async function push(token, url, branchName, message, committerUsername, committe
     .addConfig('user.email', committerEmail)
     .commit(message)
     .addRemote(remoteName, authanticatedUrl(token, url, committerUsername))
-    .fetch()
     .push(['-u', remoteName, branchName]);
 }
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,4 +1,4 @@
-module.exports = {createBranch, clone, push, removeRemoteBranch, checkout};
+module.exports = {createBranch, clone, push, removeRemoteBranch};
 
 const remoteName = 'auth';
 
@@ -7,15 +7,9 @@ async function createBranch(branchName, git) {
     .checkout(`-b${branchName}`);
 }
 
-async function checkout(branchName, git) {
+async function clone(remote, dir, branchName, git) {
   return await git
-    .fetch('origin', branchName)
-    .checkout(branchName);
-}
-
-async function clone(remote, dir, git) {
-  return await git
-    .clone(remote, dir, {'--depth': 1});
+    .clone(remote, dir, {'--depth': 1, '--branch': branchName});
 }
 
 async function push(token, url, branchName, message, committerUsername, committerEmail, git) {

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,4 +1,4 @@
-module.exports = {createBranch, clone, push};
+module.exports = {createBranch, clone, push, removeRemoteBranch};
 
 async function createBranch(branchName, git) {
   return await git
@@ -23,5 +23,9 @@ async function push(token, url, branchName, message, committerUsername, committe
     .commit(message)
     .addRemote('auth', authanticatedUrl(token, url, committerUsername))
     .push(['-u', 'auth', branchName]);
+}
+
+async function removeRemoteBranch(branchName, git) {
+  return await git.push(['-u', 'auth', branchName, '--delete', '--force']);
 }
   

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,7 @@ async function run() {
       //after clonning repo, we need to checkout this specific branch
       if (baseBranchName) {
         core.info(`Checking out branch ${baseBranchWhereApplyChanges}.`);
-        await checkout(baseBranchWhereApplyChanges);
+        await checkout(baseBranchWhereApplyChanges, git);
       }
     } catch (error) {
       core.warning(`Cloning failed: ${ error}`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const simpleGit = require('simple-git');
 const path = require('path');
 const {mkdir} = require('fs').promises;
 
-const { createBranch, clone, push } = require('./git');
+const { createBranch, clone, push, removeRemoteBranch } = require('./git');
 const { getReposList, createPr, getRepoDefaultBranch } = require('./api-calls');
 const { readPackageJson, parseCommaList, verifyDependencyType, installDependency } = require('./utils');
 
@@ -14,79 +14,127 @@ const { readPackageJson, parseCommaList, verifyDependencyType, installDependency
  * It looks complex because of extensive usage of core package to log as much as possible
  */
 async function run() {
+  const gitHubKey = process.env.GITHUB_TOKEN || core.getInput('github_token', { required: true });
+  const committerUsername = core.getInput('committer_username') || 'web-flow';
+  const committerEmail = core.getInput('committer_email') || 'noreply@github.com';
+  const packageJsonPath = process.env.PACKAGE_JSON_LOC || core.getInput('packagejson_path') || './';
+  const { name: dependencyName, version: dependencyVersion} = await readPackageJson(path.join(packageJsonPath, 'package.json'));
+  core.info(`Identified dependency name as ${dependencyName} with version ${dependencyVersion}. Now it will be bumped in dependent projects.`);
+  const commitMessageProd = core.getInput('commit_message_prod') || `fix: update ${dependencyName} to ${dependencyVersion} version`;
+  const commitMessageDev = core.getInput('commit_message_dev') || `chore: update ${dependencyName} to ${dependencyVersion} version`;
+  const reposToIgnore = core.getInput('repos_to_ignore');
+  const baseBranchName = core.getInput('base_branch');
+
+  const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+  const octokit = github.getOctokit(gitHubKey);
+  const ignoredRepositories = reposToIgnore ? parseCommaList(reposToIgnore) : [];
+  //by default repo where workflow runs should always be ignored
+  let reposList;
+
   try {
-    const gitHubKey = process.env.GITHUB_TOKEN || core.getInput('github_token', { required: true });
-    const committerUsername = core.getInput('committer_username') || 'web-flow';
-    const committerEmail = core.getInput('committer_email') || 'noreply@github.com';
-    const packageJsonPath = process.env.PACKAGE_JSON_LOC || core.getInput('packagejson_path') || './';
-    const { name: dependencyName, version: dependencyVersion} = await readPackageJson(path.join(packageJsonPath, 'package.json'));
-    core.info(`Identified dependency name as ${dependencyName} with version ${dependencyVersion}. Now it will be bumped in dependent projects.`);
-    const commitMessageProd = core.getInput('commit_message_prod') || `fix: update ${dependencyName} to ${dependencyVersion} version`;
-    const commitMessageDev = core.getInput('commit_message_dev') || `chore: update ${dependencyName} to ${dependencyVersion} version`;
-    const reposToIgnore = core.getInput('repos_to_ignore');
-
-    const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-    const octokit = github.getOctokit(gitHubKey);
-    const ignoredRepositories = reposToIgnore ? parseCommaList(reposToIgnore) : [];
-    //by default repo where workflow runs should always be ignored
-    ignoredRepositories.push(repo);
-
-    const reposList = await getReposList(octokit, dependencyName, owner);
-    core.debug('DEBUG: List of all repost returned by search without duplicates:');
-    core.debug(JSON.stringify(reposList, null, 2));
+    reposList = await getReposList(octokit, dependencyName, owner);
+  } catch (error) {
+    core.setFailed(`Action failed while getting list of repos to process: ${ error}`);
+  }
     
-    const foundReposAmount = reposList.length;
-    if (!foundReposAmount) return core.info(`No dependants found. No version bump performed. Looks like you do not use ${dependencyName} in your organization :man_shrugging:`);
+  core.debug('DEBUG: List of all repost returned by search without duplicates:');
+  core.debug(JSON.stringify(reposList, null, 2));
+    
+  const foundReposAmount = reposList.length;
+  if (!foundReposAmount) return core.info(`No dependants found. No version bump performed. Looks like you do not use ${dependencyName} in your organization :man_shrugging:`);
 
-    core.startGroup(`Iterating over ${foundReposAmount} repos from ${owner} that have ${dependencyName} in their package.json. The following repos will be later ignored: ${ignoredRepositories}`);
+  core.startGroup(`Iterating over ${foundReposAmount} repos from ${owner} that have ${dependencyName} in their package.json. The following repos will be later ignored: ${ignoredRepositories}`);
 
-    for (const {path: filepath, repository: { name, html_url, node_id }} of reposList) {
-      if (ignoredRepositories.includes(name)) continue;
-      //Sometimes there might be files like package.json.js or similar as the repository might contain some templated package.json files that cannot be parsed from string to JSON
-      //Such files must be ignored 
-      if (filepath.substring(filepath.lastIndexOf('/') + 1) !== 'package.json') {
-        core.info(`Ignoring ${filepath} from ${name} repo as only package.json files are supported`);
-        continue;
-      }
-
-      const cloneDir = path.join(process.cwd(), './clones', name);
-      await mkdir(cloneDir, {recursive: true});
-
-      const branchName = `bot/bump-${dependencyName}-${dependencyVersion}`;
-      const git = simpleGit({baseDir: cloneDir});
-
-      core.info(`Clonning ${name}.`);
-      await clone(html_url, cloneDir, git);
-      
-      core.info(`Creating branch ${branchName}.`);
-      await createBranch(branchName, git);
-      
-      core.info('Checking if dependency is prod, dev or both');
-      const packageJsonLocation = path.join(cloneDir, filepath);
-      const packageJson = await readPackageJson(packageJsonLocation);
-      const dependencyType = await verifyDependencyType(packageJson, dependencyName);
-      if (dependencyType === 'NONE') {
-        core.info(`We could not find ${dependencyName} neither in dependencies property nor in the devDependencies property. No further steps will be performed. It was found as GitHub search is not perfect and you probably use a package with similar name.`);
-        continue;
-      }
-
-      core.info('Bumping version');
-      await installDependency(dependencyName, dependencyVersion, packageJsonLocation);
-      const commitMessage = dependencyType === 'PROD' ? commitMessageProd : commitMessageDev;
-
-      core.info('Pushing changes to remote');
-      await push(gitHubKey, html_url, branchName, commitMessage, committerUsername, committerEmail, git);
-      
-      core.info('Creating PR');
-      const pullRequestUrl = await createPr(octokit, branchName, node_id, commitMessage, await getRepoDefaultBranch(octokit, name, owner));
-      
-      core.info(`Finished with success and PR for ${name} is created -> ${pullRequestUrl}`);
+  for (const {path: filepath, repository: { name, html_url, node_id }} of reposList) {
+    if (ignoredRepositories.includes(name)) continue;
+    //Sometimes there might be files like package.json.js or similar as the repository might contain some templated package.json files that cannot be parsed from string to JSON
+    //Such files must be ignored 
+    if (filepath.substring(filepath.lastIndexOf('/') + 1) !== 'package.json') {
+      core.info(`Ignoring ${filepath} from ${name} repo as only package.json files are supported`);
+      continue;
     }
 
-    core.endGroup();
-  } catch (error) {
-    core.setFailed(`Action failed because of: ${ error}`);
+    const cloneDir = path.join(process.cwd(), './clones', name);
+    try {
+      await mkdir(cloneDir, {recursive: true});
+    } catch (error) {
+      core.warning(`Unable to create directory where close should end up: ${ error}`);
+    }
+
+    const branchName = `bot/bump-${dependencyName}-${dependencyVersion}`;
+    const git = simpleGit({baseDir: cloneDir});
+
+    core.info(`Clonning ${name}.`);
+    try {
+      await clone(html_url, cloneDir, git);
+    } catch (error) {
+      core.warning(`Cloning failed: ${ error}`);
+      continue;
+    }
+      
+    core.info(`Creating branch ${branchName}.`);
+    try {
+      await createBranch(branchName, git);
+    } catch (error) {
+      core.warning(`Branch creation failes: ${ error}`);
+      continue;
+    }
+      
+    core.info('Checking if dependency is prod, dev or both');
+    const packageJsonLocation = path.join(cloneDir, filepath);
+    let packageJson;
+    let dependencyType;
+    try {
+      packageJson = await readPackageJson(packageJsonLocation);
+      dependencyType = await verifyDependencyType(packageJson, dependencyName);
+    } catch (error) {
+      core.warning(`Verification of dependency failed: ${ error}`);
+      continue;
+    }
+      
+    if (dependencyType === 'NONE') {
+      core.info(`We could not find ${dependencyName} neither in dependencies property nor in the devDependencies property. No further steps will be performed. It was found as GitHub search is not perfect and you probably use a package with similar name.`);
+      continue;
+    }
+
+    core.info('Bumping version');
+    try {
+      await installDependency(dependencyName, dependencyVersion, packageJsonLocation);
+    } catch (error) {
+      core.warning(`Dependency installation failed: ${ error}`);
+      continue;
+    }
+    const commitMessage = dependencyType === 'PROD' ? commitMessageProd : commitMessageDev;
+
+    core.info('Pushing changes to remote');
+    try {
+      await push(gitHubKey, html_url, branchName, commitMessage, committerUsername, committerEmail, git);
+    } catch (error) {
+      core.warning(`Pushing changes failed: ${ error}`);
+      continue;
+    }
+      
+    let pullRequestUrl;
+    const baseBranchWhereApplyChanges = baseBranchName || await getRepoDefaultBranch(octokit, name, owner);
+    core.info('Creating PR');
+    try {
+      pullRequestUrl = await createPr(octokit, branchName, node_id, commitMessage, baseBranchWhereApplyChanges);
+    } catch (error) {
+      core.warning(`Opening PR failed: ${ error}`);
+      core.info('Attempting to remove branch that was initially pushed to remote');
+      try {
+        //we should cleanup dead branch from remote if PR creation is not possible
+        await removeRemoteBranch(branchName, git);
+      } catch (error) {
+        core.warning(`Could not remove branch in remote after failed PR creation: ${ error}`);
+      }
+      continue;
+    }
+      
+    core.info(`Finished with success and PR for ${name} is created -> ${pullRequestUrl}`);
   }
+
+  core.endGroup();
 }
 
 run();

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const simpleGit = require('simple-git');
 const path = require('path');
 const {mkdir} = require('fs').promises;
 
-const { createBranch, clone, push, removeRemoteBranch, checkout } = require('./git');
+const { createBranch, clone, push, removeRemoteBranch } = require('./git');
 const { getReposList, createPr, getRepoDefaultBranch } = require('./api-calls');
 const { readPackageJson, parseCommaList, verifyDependencyType, installDependency } = require('./utils');
 
@@ -55,26 +55,19 @@ async function run() {
     }
 
     const baseBranchWhereApplyChanges = baseBranchName || await getRepoDefaultBranch(octokit, name, owner);
-
+    const branchName = `bot/bump-${dependencyName}-${dependencyVersion}`;
     const cloneDir = path.join(process.cwd(), './clones', name);
+    const git = simpleGit({baseDir: cloneDir});
+
     try {
       await mkdir(cloneDir, {recursive: true});
     } catch (error) {
       core.warning(`Unable to create directory where close should end up: ${ error}`);
     }
 
-    const branchName = `bot/bump-${dependencyName}-${dependencyVersion}`;
-    const git = simpleGit({baseDir: cloneDir});
-
-    core.info(`Clonning ${name}.`);
+    core.info(`Clonning ${name} with branch ${baseBranchWhereApplyChanges}.`);
     try {
-      await clone(html_url, cloneDir, git);
-      //in case some different than default branch was provided in config
-      //after clonning repo, we need to checkout this specific branch
-      if (baseBranchName) {
-        core.info(`Checking out branch ${baseBranchWhereApplyChanges}.`);
-        await checkout(baseBranchWhereApplyChanges, git);
-      }
+      await clone(html_url, cloneDir, baseBranchWhereApplyChanges, git);
     } catch (error) {
       core.warning(`Cloning failed: ${ error}`);
       continue;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const simpleGit = require('simple-git');
 const path = require('path');
 const {mkdir} = require('fs').promises;
 
-const { createBranch, clone, push, removeRemoteBranch } = require('./git');
+const { createBranch, clone, push, removeRemoteBranch, checkout } = require('./git');
 const { getReposList, createPr, getRepoDefaultBranch } = require('./api-calls');
 const { readPackageJson, parseCommaList, verifyDependencyType, installDependency } = require('./utils');
 
@@ -54,6 +54,8 @@ async function run() {
       continue;
     }
 
+    const baseBranchWhereApplyChanges = baseBranchName || await getRepoDefaultBranch(octokit, name, owner);
+
     const cloneDir = path.join(process.cwd(), './clones', name);
     try {
       await mkdir(cloneDir, {recursive: true});
@@ -67,11 +69,12 @@ async function run() {
     core.info(`Clonning ${name}.`);
     try {
       await clone(html_url, cloneDir, git);
+      if (baseBranchName) await checkout(baseBranchWhereApplyChanges);
     } catch (error) {
       core.warning(`Cloning failed: ${ error}`);
       continue;
     }
-      
+
     core.info(`Creating branch ${branchName}.`);
     try {
       await createBranch(branchName, git);
@@ -115,7 +118,6 @@ async function run() {
     }
       
     let pullRequestUrl;
-    const baseBranchWhereApplyChanges = baseBranchName || await getRepoDefaultBranch(octokit, name, owner);
     core.info('Creating PR');
     try {
       pullRequestUrl = await createPr(octokit, branchName, node_id, commitMessage, baseBranchWhereApplyChanges);

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,12 @@ async function run() {
     core.info(`Clonning ${name}.`);
     try {
       await clone(html_url, cloneDir, git);
-      if (baseBranchName) await checkout(baseBranchWhereApplyChanges);
+      //in case some different than default branch was provided in config
+      //after clonning repo, we need to checkout this specific branch
+      if (baseBranchName) {
+        core.info(`Checking out branch ${baseBranchWhereApplyChanges}.`);
+        await checkout(baseBranchWhereApplyChanges);
+      }
     } catch (error) {
       core.warning(`Cloning failed: ${ error}`);
       continue;

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,6 @@ async function run() {
     const baseBranchWhereApplyChanges = baseBranchName || await getRepoDefaultBranch(octokit, name, owner);
     const branchName = `bot/bump-${dependencyName}-${dependencyVersion}`;
     const cloneDir = path.join(process.cwd(), './clones', name);
-    const git = simpleGit({baseDir: cloneDir});
 
     try {
       await mkdir(cloneDir, {recursive: true});
@@ -65,6 +64,8 @@ async function run() {
       core.warning(`Unable to create directory where close should end up: ${ error}`);
     }
 
+    const git = simpleGit({baseDir: cloneDir});
+    
     core.info(`Clonning ${name} with branch ${baseBranchWhereApplyChanges}.`);
     try {
       await clone(html_url, cloneDir, baseBranchWhereApplyChanges, git);


### PR DESCRIPTION
- Now while updating multiple repositories, if there are issues with one of them, the action doesn't fail but continues bumping deps in next repo from the list. 
- added new configuration `base_branch` to enable bumping in custom branches, not default only.
- CONSIDERED A BREAKING CHANGE as this is change in how action behaves. Now when PR creation fails because of duplicated PR (when base and compare is the same in another PR already), initially created and pushed branch is deleted to cleanup not needed trash

worked here https://github.com/lukasz-lab/banka-wstanka/pull/41

fixes #8 