### PR TITLE
fix: GraphQL API call to create PR failing due to mistype

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1827,16 +1827,14 @@ async function getReposList(octokit, name, owner) {
     q: `"${name}" user:${owner} in:file filename:package.json`
   });
   
-  let processedRepo = {};
+  const processedRepo = {};
   // filter() returns only the repos that are not present in processedRepo object, and adds them there to the list
-  const deduplicatedReposList = items.filter(({ repository: { id }}) => !processedRepo[id] && (processedRepo[id] = true));
-
-  return deduplicatedReposList;
+  return items.filter(({ repository: { id }}) => !processedRepo[id] && (processedRepo[id] = true));
 }
 
 async function createPr(octokit, branchName, id, commitMessage, defaultBranch) {
   const createPrMutation =
-    `mutation createPr($branchName: String!, $id: String!, $commitMessage: String!, $defaultBranch: String!) {
+    `mutation createPr($branchName: String!, $id: ID!, $commitMessage: String!, $defaultBranch: String!) {
       createPullRequest(input: {
         baseRefName: $defaultBranch,
         headRefName: $branchName,

--- a/lib/api-calls.js
+++ b/lib/api-calls.js
@@ -5,16 +5,14 @@ async function getReposList(octokit, name, owner) {
     q: `"${name}" user:${owner} in:file filename:package.json`
   });
   
-  let processedRepo = {};
+  const processedRepo = {};
   // filter() returns only the repos that are not present in processedRepo object, and adds them there to the list
-  const deduplicatedReposList = items.filter(({ repository: { id }}) => !processedRepo[id] && (processedRepo[id] = true));
-
-  return deduplicatedReposList;
+  return items.filter(({ repository: { id }}) => !processedRepo[id] && (processedRepo[id] = true));
 }
 
 async function createPr(octokit, branchName, id, commitMessage, defaultBranch) {
   const createPrMutation =
-    `mutation createPr($branchName: String!, $id: String!, $commitMessage: String!, $defaultBranch: String!) {
+    `mutation createPr($branchName: String!, $id: ID!, $commitMessage: String!, $defaultBranch: String!) {
       createPullRequest(input: {
         baseRefName: $defaultBranch,
         headRefName: $branchName,


### PR DESCRIPTION
now workflow doesn't work because if `Warning: Opening PR failed: GraphqlError: Type mismatch on variable $id and argument repositoryId (String! / ID!)`