### PR TITLE
fix: make sure own repo is ignored during bumping

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11450,6 +11450,7 @@ async function run() {
   const octokit = github.getOctokit(gitHubKey);
   const ignoredRepositories = reposToIgnore ? parseCommaList(reposToIgnore) : [];
   //by default repo where workflow runs should always be ignored
+  ignoredRepositories.push(repo);
   let reposList;
 
   try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,7 @@ async function run() {
   const octokit = github.getOctokit(gitHubKey);
   const ignoredRepositories = reposToIgnore ? parseCommaList(reposToIgnore) : [];
   //by default repo where workflow runs should always be ignored
+  ignoredRepositories.push(repo);
   let reposList;
 
   try {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

During some old refactoring https://github.com/derberg/npm-dependency-manager-for-your-github-org/commit/e3baee75dd8dea7a4c9ab6f2c419f19f8d381fca#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1L32 line was removed from the code, and it was responsible from ignoring the repo where the workflow is running.