### PR TITLE
feat!: upgrade action node engine to `node16`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Bumping
-        uses: derberg/npm-dependency-manager-for-your-github-org@v4
+        uses: derberg/npm-dependency-manager-for-your-github-org@v5
         with:
           github_token: ${{ secrets.CUSTOM_TOKEN }}
           repos_to_ignore: repo1,repo2

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
       In the format: `next-major`.
     required: false
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: chevrons-up


### PR DESCRIPTION
related to https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/