### PR TITLE
feat: handle multiple package.json in single repo

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1837,6 +1837,8 @@ async function getReposList(octokit, name, owner) {
     } else {
       acc[index].paths.push(path);
     }
+
+    return acc;
   }, []);
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1827,9 +1827,17 @@ async function getReposList(octokit, name, owner) {
     q: `"${name}" user:${owner} in:file filename:package.json`
   });
   
-  const processedRepo = {};
-  // filter() returns only the repos that are not present in processedRepo object, and adds them there to the list
-  return items.filter(({ repository: { id }}) => !processedRepo[id] && (processedRepo[id] = true));
+  // Groups paths by repository id
+  return items.reduce((acc, item) => {
+    const index = acc.findIndex(repo => repo.id === item.repository.id);
+    const path = item.path;
+    delete item.path;
+    if (index === -1) {
+      acc.push({ ...item, paths: [path] });
+    } else {
+      acc[index].paths.push(path);
+    }
+  }, []);
 }
 
 async function createPr(octokit, branchName, id, commitMessage, defaultBranch) {
@@ -11467,18 +11475,12 @@ async function run() {
 
   core.startGroup(`Iterating over ${foundReposAmount} repos from ${owner} that have ${dependencyName} in their package.json. The following repos will be later ignored: ${ignoredRepositories}`);
 
-  for (const {path: filepath, repository: { name, html_url, node_id }} of reposList) {
+  for (const {paths: filepaths, repository: { name, html_url, node_id }} of reposList) {
     if (ignoredRepositories.includes(name)) continue;
-    //Sometimes there might be files like package.json.js or similar as the repository might contain some templated package.json files that cannot be parsed from string to JSON
-    //Such files must be ignored 
-    if (filepath.substring(filepath.lastIndexOf('/') + 1) !== 'package.json') {
-      core.info(`Ignoring ${filepath} from ${name} repo as only package.json files are supported`);
-      continue;
-    }
 
     const baseBranchWhereApplyChanges = baseBranchName || await getRepoDefaultBranch(octokit, name, owner);
     const branchName = `bot/bump-${dependencyName}-${dependencyVersion}`;
-    const cloneDir = __webpack_require__.ab + "clones/" + name;
+    const cloneDir = path.join(process.cwd(), './clones', name);
 
     try {
       await mkdir(cloneDir, {recursive: true});
@@ -11503,32 +11505,48 @@ async function run() {
       core.warning(`Branch creation failes: ${ error}`);
       continue;
     }
-      
-    core.info('Checking if dependency is prod, dev or both');
-    const packageJsonLocation = path.join(cloneDir, filepath);
-    let packageJson;
-    let dependencyType;
-    try {
-      packageJson = await readPackageJson(packageJsonLocation);
-      dependencyType = await verifyDependencyType(packageJson, dependencyName);
-    } catch (error) {
-      core.warning(`Verification of dependency failed: ${ error}`);
-      continue;
-    }
-      
-    if (dependencyType === 'NONE') {
-      core.info(`We could not find ${dependencyName} neither in dependencies property nor in the devDependencies property. No further steps will be performed. It was found as GitHub search is not perfect and you probably use a package with similar name.`);
-      continue;
+
+    let repoDependencyType;
+
+    for (const filepath of filepaths) {
+      //Sometimes there might be files like package.json.js or similar as the repository might contain some templated package.json files that cannot be parsed from string to JSON
+      //Such files must be ignored 
+      if (filepath.substring(filepath.lastIndexOf('/') + 1) !== 'package.json') {
+        core.info(`Ignoring ${filepath} from ${name} repo as only package.json files are supported`);
+        continue;
+      }
+
+      core.info('Checking if dependency is prod, dev or both');
+      const packageJsonLocation = path.join(cloneDir, filepath);
+      let packageJson;
+      let dependencyType;
+      try {
+        packageJson = await readPackageJson(packageJsonLocation);
+        dependencyType = await verifyDependencyType(packageJson, dependencyName);
+      } catch (error) {
+        core.warning(`Verification of dependency failed: ${ error}`);
+        continue;
+      }
+        
+      if (dependencyType === 'NONE') {
+        core.info(`We could not find ${dependencyName} neither in dependencies property nor in the devDependencies property. No further steps will be performed. It was found as GitHub search is not perfect and you probably use a package with similar name.`);
+        continue;
+      }
+
+      core.info(`Bumping ${dependencyName} in file ${filepath} in ${name} repo`);
+      try {
+        await installDependency(dependencyName, dependencyVersion, packageJsonLocation);
+      } catch (error) {
+        core.warning(`Dependency installation failed: ${ error}`);
+        continue;
+      }
+
+      if (dependencyType === 'PROD') {
+        repoDependencyType = 'PROD';
+      }
     }
 
-    core.info('Bumping version');
-    try {
-      await installDependency(dependencyName, dependencyVersion, packageJsonLocation);
-    } catch (error) {
-      core.warning(`Dependency installation failed: ${ error}`);
-      continue;
-    }
-    const commitMessage = dependencyType === 'PROD' ? commitMessageProd : commitMessageDev;
+    const commitMessage = repoDependencyType === 'PROD' ? commitMessageProd : commitMessageDev;
 
     core.info('Pushing changes to remote');
     try {
@@ -11537,7 +11555,7 @@ async function run() {
       core.warning(`Pushing changes failed: ${ error}`);
       continue;
     }
-      
+    
     let pullRequestUrl;
     core.info('Creating PR');
     try {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1829,7 +1829,7 @@ async function getReposList(octokit, name, owner) {
   
   // Groups paths by repository id
   return items.reduce((acc, item) => {
-    const index = acc.findIndex(repo => repo.id === item.repository.id);
+    const index = acc.findIndex(repo => repo.repository.id === item.repository.id);
     const path = item.path;
     delete item.path;
     if (index === -1) {

--- a/lib/api-calls.js
+++ b/lib/api-calls.js
@@ -15,6 +15,8 @@ async function getReposList(octokit, name, owner) {
     } else {
       acc[index].paths.push(path);
     }
+
+    return acc;
   }, []);
 }
 

--- a/lib/api-calls.js
+++ b/lib/api-calls.js
@@ -7,7 +7,7 @@ async function getReposList(octokit, name, owner) {
   
   // Groups paths by repository id
   return items.reduce((acc, item) => {
-    const index = acc.findIndex(repo => repo.id === item.repository.id);
+    const index = acc.findIndex(repo => repo.repository.id === item.repository.id);
     const path = item.path;
     delete item.path;
     if (index === -1) {

--- a/lib/api-calls.js
+++ b/lib/api-calls.js
@@ -5,9 +5,17 @@ async function getReposList(octokit, name, owner) {
     q: `"${name}" user:${owner} in:file filename:package.json`
   });
   
-  const processedRepo = {};
-  // filter() returns only the repos that are not present in processedRepo object, and adds them there to the list
-  return items.filter(({ repository: { id }}) => !processedRepo[id] && (processedRepo[id] = true));
+  // Groups paths by repository id
+  return items.reduce((acc, item) => {
+    const index = acc.findIndex(repo => repo.id === item.repository.id);
+    const path = item.path;
+    delete item.path;
+    if (index === -1) {
+      acc.push({ ...item, paths: [path] });
+    } else {
+      acc[index].paths.push(path);
+    }
+  }, []);
 }
 
 async function createPr(octokit, branchName, id, commitMessage, defaultBranch) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,14 +46,8 @@ async function run() {
 
   core.startGroup(`Iterating over ${foundReposAmount} repos from ${owner} that have ${dependencyName} in their package.json. The following repos will be later ignored: ${ignoredRepositories}`);
 
-  for (const {path: filepath, repository: { name, html_url, node_id }} of reposList) {
+  for (const {paths: filepaths, repository: { name, html_url, node_id }} of reposList) {
     if (ignoredRepositories.includes(name)) continue;
-    //Sometimes there might be files like package.json.js or similar as the repository might contain some templated package.json files that cannot be parsed from string to JSON
-    //Such files must be ignored 
-    if (filepath.substring(filepath.lastIndexOf('/') + 1) !== 'package.json') {
-      core.info(`Ignoring ${filepath} from ${name} repo as only package.json files are supported`);
-      continue;
-    }
 
     const baseBranchWhereApplyChanges = baseBranchName || await getRepoDefaultBranch(octokit, name, owner);
     const branchName = `bot/bump-${dependencyName}-${dependencyVersion}`;
@@ -82,32 +76,48 @@ async function run() {
       core.warning(`Branch creation failes: ${ error}`);
       continue;
     }
-      
-    core.info('Checking if dependency is prod, dev or both');
-    const packageJsonLocation = path.join(cloneDir, filepath);
-    let packageJson;
-    let dependencyType;
-    try {
-      packageJson = await readPackageJson(packageJsonLocation);
-      dependencyType = await verifyDependencyType(packageJson, dependencyName);
-    } catch (error) {
-      core.warning(`Verification of dependency failed: ${ error}`);
-      continue;
-    }
-      
-    if (dependencyType === 'NONE') {
-      core.info(`We could not find ${dependencyName} neither in dependencies property nor in the devDependencies property. No further steps will be performed. It was found as GitHub search is not perfect and you probably use a package with similar name.`);
-      continue;
+
+    let repoDependencyType;
+
+    for (const filepath of filepaths) {
+      //Sometimes there might be files like package.json.js or similar as the repository might contain some templated package.json files that cannot be parsed from string to JSON
+      //Such files must be ignored 
+      if (filepath.substring(filepath.lastIndexOf('/') + 1) !== 'package.json') {
+        core.info(`Ignoring ${filepath} from ${name} repo as only package.json files are supported`);
+        continue;
+      }
+
+      core.info('Checking if dependency is prod, dev or both');
+      const packageJsonLocation = path.join(cloneDir, filepath);
+      let packageJson;
+      let dependencyType;
+      try {
+        packageJson = await readPackageJson(packageJsonLocation);
+        dependencyType = await verifyDependencyType(packageJson, dependencyName);
+      } catch (error) {
+        core.warning(`Verification of dependency failed: ${ error}`);
+        continue;
+      }
+        
+      if (dependencyType === 'NONE') {
+        core.info(`We could not find ${dependencyName} neither in dependencies property nor in the devDependencies property. No further steps will be performed. It was found as GitHub search is not perfect and you probably use a package with similar name.`);
+        continue;
+      }
+
+      core.info(`Bumping ${dependencyName} in file ${filepath} in ${name} repo`);
+      try {
+        await installDependency(dependencyName, dependencyVersion, packageJsonLocation);
+      } catch (error) {
+        core.warning(`Dependency installation failed: ${ error}`);
+        continue;
+      }
+
+      if (dependencyType === 'PROD') {
+        repoDependencyType = 'PROD';
+      }
     }
 
-    core.info('Bumping version');
-    try {
-      await installDependency(dependencyName, dependencyVersion, packageJsonLocation);
-    } catch (error) {
-      core.warning(`Dependency installation failed: ${ error}`);
-      continue;
-    }
-    const commitMessage = dependencyType === 'PROD' ? commitMessageProd : commitMessageDev;
+    const commitMessage = repoDependencyType === 'PROD' ? commitMessageProd : commitMessageDev;
 
     core.info('Pushing changes to remote');
     try {
@@ -116,7 +126,7 @@ async function run() {
       core.warning(`Pushing changes failed: ${ error}`);
       continue;
     }
-      
+    
     let pullRequestUrl;
     core.info('Creating PR');
     try {


### PR DESCRIPTION
### Description
- Currently the search api was returning multiple items for multiple package.json which were being removed upon filtering.
- This PR improves the action by grouping the filepaths into an array and bumping version in each filepath.
- Further information can be found [here](https://github.com/asyncapi/cli/issues/923#issuecomment-1847279095)

### Issues fixed
Fixes #14